### PR TITLE
feat(aos): Add Loki webhook support for alert routing

### DIFF
--- a/charts/aos/templates/statefulsets.yaml
+++ b/charts/aos/templates/statefulsets.yaml
@@ -209,6 +209,8 @@ spec:
               value: "duplo-otel-alerting"
             - name: AOS_AUTOMATION_WEBHOOK
               value: "{{ .Values.global.automationWebhookUrl }}"
+            - name: AOS_LOKI_WEBHOOK
+              value: "{{ .Values.global.automationLokiWebhookUrl }}"
             - name: AOS_DUPLO_PORTAL_NAME
               value: "{{ .Values.global.customerName }}-{{ .Values.global.environment }}"
             - name: AOS_NAMESPACE_FILTER

--- a/charts/aos/values.yaml
+++ b/charts/aos/values.yaml
@@ -12,6 +12,7 @@ global:
   slackWebhookUrl: ""
   oncallWebhookUrl: ""
   automationWebhookUrl: "http://duplo-automation:5000/alertmanager/webhook"
+  automationLokiWebhookUrl: "http://duplo-automation:5000/alertmanager/loki-webhook"
   cloud: ""
   duploReleaseBranch: "main"
   


### PR DESCRIPTION
## Summary

- Adds `AOS_LOKI_WEBHOOK` environment variable to the AOS StatefulSet, pointing to the Loki webhook endpoint on `duplo-automation`
- Adds `automationLokiWebhookUrl` default value in `globals` (`http://duplo-automation:5000/alertmanager/loki-webhook`)
- Bumps chart version to `2.1.24`

## Changes

| File | Change |
|------|--------|
| `charts/aos/templates/statefulsets.yaml` | Added `AOS_LOKI_WEBHOOK` env var referencing `global.automationLokiWebhookUrl` |
| `charts/aos/values.yaml` | Added default value for `automationLokiWebhookUrl` |

## Test plan

- [ ] Deploy AOS chart with updated values and verify `AOS_LOKI_WEBHOOK` env var is set correctly in the StatefulSet pod
- [ ] Confirm Loki alerts are routed to `duplo-automation:5000/alertmanager/loki-webhook`
- [ ] Verify existing `AOS_AUTOMATION_WEBHOOK` behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)