### PR TITLE
feat(aos): upgrade Grafana to 13.0.2 and increase resource limits

### DIFF
--- a/charts/aos/values.yaml
+++ b/charts/aos/values.yaml
@@ -21,13 +21,13 @@ grafanaUI:
   enabled: true
   replicas: 1
   image: "duplocloud/otel-dashboards"
-  imageTag: "12.4.2-v1"
+  imageTag: "13.0.2-v1"
   resources:
     limits:
-      cpu: "100m"
-      memory: "512Mi"
+      cpu: "300m"
+      memory: "1Gi"
     requests:
-      cpu: "100m"
+      cpu: "300m"
       memory: "512Mi"
   volume:
     size: "10Gi"

--- a/charts/aos/values.yaml
+++ b/charts/aos/values.yaml
@@ -28,7 +28,7 @@ grafanaUI:
       memory: "1Gi"
     requests:
       cpu: "300m"
-      memory: "512Mi"
+      memory: "1Gi"
   volume:
     size: "10Gi"
   nodeSelector: 


### PR DESCRIPTION
Bump grafanaUI imageTag from 12.4.2-v1 to 13.0.2-v1 to upgrade Grafana to version 13.0.2. Increase CPU requests/limits from 100m to 300m and memory limit from 512Mi to 1Gi to accommodate the higher resource requirements of the new version.