### PR TITLE
feat(aos): serviceAccountName fallback for observability collector cronjob

### DIFF
--- a/charts/aos/templates/_helpers.tpl
+++ b/charts/aos/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "aos.serviceAccountName" -}}
+{{- .local | default .global | default (printf "%s-edit-user" .namespace) -}}
+{{- end -}}

--- a/charts/aos/templates/_helpers.tpl
+++ b/charts/aos/templates/_helpers.tpl
@@ -1,3 +1,28 @@
+{{- /*
+Return the serviceAccountName for a component.
+Call with: include "aos.serviceAccountName" (dict "root" . "component" "grafana")
+Fallback order:
+  1) .Values.<component>.serviceAccountName (if non-empty)
+  2) .Values.global.serviceAccountName (if non-empty)
+  3) "<Release.Namespace>-edit-user"
+*/ -}}
 {{- define "aos.serviceAccountName" -}}
-{{- .local | default .global | default (printf "%s-edit-user" .namespace) -}}
+  {{- $root := .root -}}
+  {{- $component := .component -}}
+  {{- $vals := $root.Values -}}
+
+  {{- /* try component-specific value first */ -}}
+  {{- $compSA := "" -}}
+  {{- if and (hasKey $vals $component) (hasKey (index $vals $component) "serviceAccountName") -}}
+    {{- $compSA = (index $vals $component "serviceAccountName") -}}
+  {{- end -}}
+
+  {{- /* treat empty string or whitespace as not set */ -}}
+  {{- if and (typeIs "string" $compSA) (ne (trim $compSA) "") -}}
+    {{- trim $compSA -}}
+  {{- else if and (hasKey $vals "global") (hasKey $vals.global "serviceAccountName") (ne (trim $vals.global.serviceAccountName) "") -}}
+    {{- trim $vals.global.serviceAccountName -}}
+  {{- else -}}
+    {{- printf "%s-edit-user" $root.Release.Namespace -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/aos/templates/cronjobs.yaml
+++ b/charts/aos/templates/cronjobs.yaml
@@ -76,6 +76,7 @@ spec:
                 {{- toYaml . | nindent 16 }}
 {{- end }}
           restartPolicy: OnFailure
+          serviceAccountName: {{ include "aos.serviceAccountName" (dict "global" .Values.global.serviceAccountName "local" .Values.observabilityCollector.serviceAccountName "namespace" .Release.Namespace) }}
 {{- if .Values.observabilityCollector.nodeSelector }}
           nodeSelector:
 {{ toYaml .Values.observabilityCollector.nodeSelector | indent 12 }}

--- a/charts/aos/templates/cronjobs.yaml
+++ b/charts/aos/templates/cronjobs.yaml
@@ -76,7 +76,7 @@ spec:
                 {{- toYaml . | nindent 16 }}
 {{- end }}
           restartPolicy: OnFailure
-          serviceAccountName: {{ include "aos.serviceAccountName" (dict "global" .Values.global.serviceAccountName "local" .Values.observabilityCollector.serviceAccountName "namespace" .Release.Namespace) }}
+          serviceAccountName: {{ include "aos.serviceAccountName" (dict "root" . "component" "observabilityCollector") }}
 {{- if .Values.observabilityCollector.nodeSelector }}
           nodeSelector:
 {{ toYaml .Values.observabilityCollector.nodeSelector | indent 12 }}

--- a/charts/aos/values.yaml
+++ b/charts/aos/values.yaml
@@ -15,7 +15,8 @@ global:
   automationLokiWebhookUrl: "http://duplo-automation:5000/alertmanager/loki-webhook"
   cloud: ""
   duploReleaseBranch: "main"
-  
+  serviceAccountName: "" # Fallback service account for all pods — overridden by per-component serviceAccountName; defaults to <namespace>-edit-user when empty
+
 # Grafana UI settings
 grafanaUI:
   enabled: true
@@ -122,6 +123,7 @@ observabilityCollector:
   jobVersion: "2.2.0"
   nodeSelector:
     allocationtags: duplo-observability
+  serviceAccountName: "" # Overrides global.serviceAccountName
   extraEnv: []
   # Source credentials for multi-tenant clusters — leave blank for single-tenant
   # Mode 1 (inline): set username + password — Helm creates the secret


### PR DESCRIPTION
## Summary

Adds a configurable `serviceAccountName` for the **observability collector cronjob** only, with a fallback chain to the DuploCloud-standard `<namespace>-edit-user`.

- **New helper** `aos.serviceAccountName` (`charts/aos/templates/_helpers.tpl`) — resolution: `observabilityCollector.serviceAccountName` → `global.serviceAccountName` → `<namespace>-edit-user`.
- **Wired into the collector cronjob** (`cronjobs.yaml`) — previously it set no SA and ran under the namespace `default` SA; it now defaults to `<namespace>-edit-user`.
- **New values keys**: `global.serviceAccountName` and `observabilityCollector.serviceAccountName` (both default `""`).

## Scope note

Scoped to the collector cronjob only. All other workloads (grafana-ui, duplo-automation, grafana-proxy, pdc, integration jobs, otel-validation job) are unchanged — the jobs still hardcode `<namespace>-edit-user` as before. No chart version bump — left for whoever cuts the release.

## Test plan

Validated with `helm template` + `helm lint` (0 failures):

- [x] Default → collector cronjob renders `<namespace>-edit-user`
- [x] `global.serviceAccountName=global-sa` → cronjob uses `global-sa`
- [x] `observabilityCollector.serviceAccountName=collector-sa` → cronjob uses `collector-sa` (local wins over global)
- [x] All other workloads unchanged vs main