### PR TITLE
Feat/grafana mcp server

### DIFF
--- a/charts/aos/README.md
+++ b/charts/aos/README.md
@@ -84,6 +84,141 @@ This Helm chart deploys the Duplo OpenTelemetry stack, including Grafana UI, syn
 | `grafanaProxy.nodeSelector`  | Node selector for pods               | `allocationtags: duplo-observability` |
 
 
+## Grafana MCP Server Configuration
+
+The Grafana MCP server exposes Grafana capabilities (dashboards, metrics, logs, alerts, annotations) as [Model Context Protocol](https://modelcontextprotocol.io) tools, enabling AI agents (Claude Code, helpdesk portals, customer AI agents) to query and interact with the observability stack.
+
+### Architecture
+
+```
+AI agent / helpdesk portal / customer
+        │  Authorization: Bearer <duplo-api-token>
+        ▼
+grafana-mcp-proxy:80   (duplocloud/sso-proxy — validates Duplo auth)
+        ▼
+grafana-mcp-server:8080  (ghcr.io/grafana/mcp-grafana — cluster-internal)
+        ▼
+grafana-ui:3000
+```
+
+A post-install/upgrade Helm hook job automatically creates a Grafana service account with the configured role and writes its token into a Kubernetes secret (`grafana-mcp-server`). The MCP server picks up the token on startup.
+
+### MCP Server
+
+| Key | Description | Default Value |
+|-----|-------------|---------------|
+| `grafanaMCP.enabled` | Enable or disable the Grafana MCP server | `false` |
+| `grafanaMCP.replicas` | Number of replicas | `1` |
+| `grafanaMCP.image` | Docker image | `grafana/mcp-grafana` |
+| `grafanaMCP.imageTag` | Image tag | `1.0.0` |
+| `grafanaMCP.resources` | Resource requests and limits | CPU: `100m`, Memory: `256Mi` |
+| `grafanaMCP.nodeSelector` | Node selector for pods | `allocationtags: duplo-observability` |
+| `grafanaMCP.grafanaUrl` | Internal Grafana URL the MCP server connects to | `http://grafana-ui:3000` |
+| `grafanaMCP.allowedHosts` | Comma-separated list of allowed Host header values. Set to `*` to allow all hosts (required when accessed via an ingress with a custom domain). | `*` |
+| `grafanaMCP.serviceAccount.role` | Grafana role for the MCP service account. Valid values: `Viewer`, `Editor`, `Admin` | `Editor` |
+
+### MCP SSO Proxy
+
+The SSO proxy sits in front of the MCP server and validates every request against the Duplo auth URL. All clients (AI agents, helpdesk portals, external customers) must present a valid Duplo API token. Requires `global.duploAuthUrl` to be set.
+
+| Key | Description | Default Value |
+|-----|-------------|---------------|
+| `grafanaMCP.proxy.enabled` | Enable or disable the SSO proxy | `true` |
+| `grafanaMCP.proxy.replicas` | Number of replicas | `1` |
+| `grafanaMCP.proxy.nodeSelector` | Node selector for pods | `allocationtags: duplo-observability` |
+
+> **Proxy image and resources** are shared with `grafanaProxy` (`duplocloud/sso-proxy`). The proxy is configured with `proxy_buffering off` so SSE streams are flushed immediately to the client — do not add `proxy_http_version` to the nginx config as it is already set by the base template and will cause a duplicate-directive crash.
+
+### Service Account Setup Job
+
+A `post-install,post-upgrade` Helm hook job runs automatically to provision the Grafana service account and token:
+
+1. Waits for Grafana (`grafanaMCP.grafanaUrl/api/health`) to be healthy
+2. Creates a service account named `mcp-server` with `grafanaMCP.serviceAccount.role` (idempotent — skips creation if already exists)
+3. Rotates the token on every upgrade (deletes old `mcp-server-token`, creates a new one)
+4. Writes the token to the `grafana-mcp-server` Kubernetes secret via `kubectl apply`
+
+The MCP server deployment uses `optional: true` on the secret reference so it starts immediately and becomes fully authenticated once the job completes.
+
+### Required Values
+
+When `grafanaMCP.enabled=true`:
+
+| Value | Required when |
+|-------|--------------|
+| `grafanaMCP.grafanaUrl` | Always — no default will work if Grafana is not at `http://grafana-ui:3000` |
+| `global.duploAuthUrl` | `grafanaMCP.proxy.enabled=true` (default) |
+| `secrets.grafanaUI.password` | Always — used by the setup job to authenticate to the Grafana API |
+
+### Ingress
+
+The Ingress for the MCP server is managed in the `opentelemetry-stack` repository. Point the Ingress backend at:
+
+- `grafana-mcp-proxy:80` — recommended, traffic is protected by Duplo SSO auth
+- `grafana-mcp-server:8080` — direct, use only for internal cluster access or when external auth is handled elsewhere
+
+### Connecting AI Clients
+
+Clients must pass a valid DuploCloud API token as a Bearer token. Obtain one with:
+
+```bash
+duplo-jit duplo --host https://<your-duplo-host> --interactive
+```
+
+**Claude Code** (`.mcp.json` or project-level config):
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "type": "sse",
+      "url": "https://<grafana-mcp-ingress-host>/sse",
+      "headers": {
+        "Authorization": "Bearer <duplo-api-token>"
+      }
+    }
+  }
+}
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+Claude Desktop does not support `type: "sse"` with custom headers directly. Use [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) as a stdio-to-SSE bridge:
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://<grafana-mcp-ingress-host>/sse",
+        "--header",
+        "Authorization:Bearer <duplo-api-token>"
+      ]
+    }
+  }
+}
+```
+
+> Note the header format is `Authorization:Bearer <token>` with no space after the colon. DuploCloud tokens expire periodically — refresh with `duplo-jit` and update the config when the connection stops working.
+
+### Example
+
+```yaml
+grafanaMCP:
+  enabled: true
+  serviceAccount:
+    role: "Editor"
+  proxy:
+    enabled: true
+
+global:
+  duploAuthUrl: "https://your-duplo.example.com"
+```
+
+
 ## Grafana Cloud PDC Configuration
 
 | Key                             | Description                                      | Default Value                               |

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -278,11 +278,6 @@ spec:
 {{- toYaml .Values.grafanaProxy.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - NET_BIND_SERVICE
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -134,6 +134,9 @@ spec:
 {{- end }}
 
 {{- if .Values.grafanaMCP.enabled }}
+{{- if not (or (hasPrefix "http://" .Values.grafanaMCP.grafanaUrl) (hasPrefix "https://" .Values.grafanaMCP.grafanaUrl)) }}
+{{- fail "grafanaMCP.grafanaUrl must start with http:// or https://" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -156,6 +156,11 @@ spec:
     metadata:
       labels:
         app: grafana-mcp-server
+      annotations:
+        k8s_grafana_com_scrape: "true"
+        k8s_grafana_com_job: "grafana-mcp-server"
+        k8s_grafana_com_metrics_path: "/metrics"
+        k8s_grafana_com_metrics_portNumber: "8000"
     spec:
       containers:
         - name: grafana-mcp-server
@@ -198,6 +203,15 @@ spec:
             capabilities:
               drop:
                 - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: grafana-mcp-server
+                topologyKey: kubernetes.io/hostname
 {{- if .Values.grafanaMCP.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.grafanaMCP.nodeSelector | indent 8 }}
@@ -262,6 +276,22 @@ spec:
             failureThreshold: 5
           resources:
 {{- toYaml .Values.grafanaProxy.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: grafana-mcp-proxy
+                topologyKey: kubernetes.io/hostname
 {{- if .Values.grafanaMCP.proxy.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.grafanaMCP.proxy.nodeSelector | indent 8 }}

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -158,9 +158,11 @@ spec:
         - name: grafana-mcp-server
           image: "{{ .Values.grafanaMCP.image }}:{{ .Values.grafanaMCP.imageTag }}"
           imagePullPolicy: IfNotPresent
+          args:
+            - -allowed-hosts={{ .Values.grafanaMCP.allowedHosts | default "*" }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 8000
               protocol: TCP
           env:
             - name: GRAFANA_URL
@@ -172,30 +174,25 @@ spec:
                   key: token
                   optional: true
           readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-              scheme: HTTP
+            tcpSocket:
+              port: 8000
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
-            successThreshold: 1
             failureThreshold: 3
           livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-              scheme: HTTP
+            tcpSocket:
+              port: 8000
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-            successThreshold: 1
             failureThreshold: 5
           resources:
 {{- toYaml .Values.grafanaMCP.resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            runAsUser: 65532
             capabilities:
               drop:
                 - ALL
@@ -229,16 +226,18 @@ spec:
     spec:
       containers:
         - name: grafana-mcp-proxy
-          image: "{{ .Values.grafanaMCP.proxy.image }}:{{ .Values.grafanaMCP.proxy.imageTag }}"
+          image: "{{ .Values.grafanaProxy.image }}:{{ .Values.grafanaProxy.imageTag }}"
           ports:
             - name: proxy
               containerPort: 80
               protocol: TCP
           env:
             - name: DUPLO_AUTH_URL
-              value: {{ .Values.global.duploAuthUrl | quote }}
+              value: {{ required "global.duploAuthUrl is required when grafanaMCP.proxy.enabled=true" .Values.global.duploAuthUrl | quote }}
             - name: BACKEND_URL
               value: "http://grafana-mcp-server:8080"
+            - name: CUSTOM_HEADER_ADD
+              value: "proxy_buffering off;"
           readinessProbe:
             httpGet:
               path: /duplo_auth
@@ -260,7 +259,7 @@ spec:
             successThreshold: 1
             failureThreshold: 5
           resources:
-{{- toYaml .Values.grafanaMCP.proxy.resources | nindent 12 }}
+{{- toYaml .Values.grafanaProxy.resources | nindent 12 }}
 {{- if .Values.grafanaMCP.proxy.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.grafanaMCP.proxy.nodeSelector | indent 8 }}

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -172,7 +172,6 @@ spec:
                 secretKeyRef:
                   name: grafana-mcp-server
                   key: token
-                  optional: true
           readinessProbe:
             tcpSocket:
               port: 8000

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -132,3 +132,138 @@ spec:
       {{- end }}
 ---
 {{- end }}
+
+{{- if .Values.grafanaMCP.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-mcp-server
+  namespace: {{ $.Release.Namespace }}
+spec:
+  replicas: {{ .Values.grafanaMCP.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: grafana-mcp-server
+  template:
+    metadata:
+      labels:
+        app: grafana-mcp-server
+    spec:
+      containers:
+        - name: grafana-mcp-server
+          image: "{{ .Values.grafanaMCP.image }}:{{ .Values.grafanaMCP.imageTag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: GRAFANA_URL
+              value: {{ required "grafanaMCP.grafanaUrl is required when grafanaMCP.enabled=true" .Values.grafanaMCP.grafanaUrl | quote }}
+            - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-mcp-server
+                  key: token
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          resources:
+{{- toYaml .Values.grafanaMCP.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+{{- if .Values.grafanaMCP.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.grafanaMCP.nodeSelector | indent 8 }}
+{{- end }}
+---
+{{- end }}
+
+{{- if and .Values.grafanaMCP.enabled .Values.grafanaMCP.proxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-mcp-proxy
+  namespace: {{ $.Release.Namespace }}
+spec:
+  replicas: {{ .Values.grafanaMCP.proxy.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: grafana-mcp-proxy
+  template:
+    metadata:
+      labels:
+        app: grafana-mcp-proxy
+    spec:
+      containers:
+        - name: grafana-mcp-proxy
+          image: "{{ .Values.grafanaMCP.proxy.image }}:{{ .Values.grafanaMCP.proxy.imageTag }}"
+          ports:
+            - name: proxy
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: DUPLO_AUTH_URL
+              value: {{ .Values.global.duploAuthUrl | quote }}
+            - name: BACKEND_URL
+              value: "http://grafana-mcp-server:8080"
+          readinessProbe:
+            httpGet:
+              path: /duplo_auth
+              port: 80
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /duplo_auth
+              port: 80
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          resources:
+{{- toYaml .Values.grafanaMCP.proxy.resources | nindent 12 }}
+{{- if .Values.grafanaMCP.proxy.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.grafanaMCP.proxy.nodeSelector | indent 8 }}
+{{- end }}
+---
+{{- end }}

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -134,9 +134,6 @@ spec:
 {{- end }}
 
 {{- if .Values.grafanaMCP.enabled }}
-{{- if not (or (hasPrefix "http://" .Values.grafanaMCP.grafanaUrl) (hasPrefix "https://" .Values.grafanaMCP.grafanaUrl)) }}
-{{- fail "grafanaMCP.grafanaUrl must start with http:// or https://" }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/aos/templates/deployments.yaml
+++ b/charts/aos/templates/deployments.yaml
@@ -234,7 +234,7 @@ spec:
             - name: DUPLO_AUTH_URL
               value: {{ required "global.duploAuthUrl is required when grafanaMCP.proxy.enabled=true" .Values.global.duploAuthUrl | quote }}
             - name: BACKEND_URL
-              value: "http://grafana-mcp-server:8080"
+              value: "http://grafana-mcp-server:8000"
             - name: CUSTOM_HEADER_ADD
               value: "proxy_buffering off;"
           readinessProbe:

--- a/charts/aos/templates/grafana-mcp-cleanup-job.yaml
+++ b/charts/aos/templates/grafana-mcp-cleanup-job.yaml
@@ -1,0 +1,75 @@
+{{- if not .Values.grafanaMCP.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grafana-mcp-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 30
+  template:
+    spec:
+      containers:
+        - name: grafana-mcp-cleanup
+          image: "{{ .Values.integrationJob.image }}:{{ .Values.integrationJob.imageTag }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              kubectl delete secret grafana-mcp-server \
+                --namespace="{{ .Release.Namespace }}" \
+                --ignore-not-found=true \
+                && echo "grafana-mcp-server secret removed (or was already absent)"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+      serviceAccountName: {{ .Release.Namespace }}-edit-user
+      restartPolicy: Never
+{{- if .Values.grafanaMCP.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.grafanaMCP.nodeSelector | indent 8 }}
+{{- end }}
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grafana-mcp-cleanup-on-delete
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 30
+  template:
+    spec:
+      containers:
+        - name: grafana-mcp-cleanup
+          image: "{{ .Values.integrationJob.image }}:{{ .Values.integrationJob.imageTag }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              kubectl delete secret grafana-mcp-server \
+                --namespace="{{ .Release.Namespace }}" \
+                --ignore-not-found=true \
+                && echo "grafana-mcp-server secret removed (or was already absent)"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+      serviceAccountName: {{ .Release.Namespace }}-edit-user
+      restartPolicy: Never

--- a/charts/aos/templates/grafana-mcp-cleanup-job.yaml
+++ b/charts/aos/templates/grafana-mcp-cleanup-job.yaml
@@ -38,38 +38,3 @@ spec:
 {{ toYaml .Values.grafanaMCP.nodeSelector | indent 8 }}
 {{- end }}
 {{- end }}
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: grafana-mcp-cleanup-on-delete
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-spec:
-  backoffLimit: 0
-  activeDeadlineSeconds: 30
-  template:
-    spec:
-      containers:
-        - name: grafana-mcp-cleanup
-          image: "{{ .Values.integrationJob.image }}:{{ .Values.integrationJob.imageTag }}"
-          command:
-            - /bin/sh
-            - -c
-            - |
-              kubectl delete secret grafana-mcp-server \
-                --namespace="{{ .Release.Namespace }}" \
-                --ignore-not-found=true \
-                && echo "grafana-mcp-server secret removed (or was already absent)"
-          resources:
-            requests:
-              cpu: "50m"
-              memory: "64Mi"
-            limits:
-              cpu: "100m"
-              memory: "128Mi"
-      serviceAccountName: {{ .Release.Namespace }}-edit-user
-      restartPolicy: Never

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -56,6 +56,12 @@ spec:
             - |
               set -e
 
+              if [ -z "${GF_ADMIN_USER}" ] || [ -z "${GF_ADMIN_PASS}" ]; then
+                echo "❌ GF_ADMIN_USER or GF_ADMIN_PASS is empty."
+                echo "   Ensure the 'grafanaui' secret exists in namespace {{ .Release.Namespace }} with 'username' and 'password' keys."
+                exit 1
+              fi
+
               GRAFANA_URL="{{ .Values.grafanaMCP.grafanaUrl }}"
               SA_NAME="mcp-server"
               TOKEN_NAME="mcp-server-token"
@@ -145,11 +151,13 @@ spec:
                 secretKeyRef:
                   name: grafanaui
                   key: username
+                  optional: true
             - name: GF_ADMIN_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafanaui
                   key: password
+                  optional: true
       serviceAccountName: {{ .Release.Namespace }}-edit-user
       restartPolicy: Never
 {{- if .Values.grafanaMCP.nodeSelector }}

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-weight": "15"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 0
@@ -21,7 +21,7 @@ spec:
             - |
               set -e
 
-              GRAFANA_URL="http://grafana-ui:3000"
+              GRAFANA_URL="{{ .Values.grafanaMCP.grafanaUrl }}"
               SA_NAME="mcp-server"
               TOKEN_NAME="mcp-server-token"
               SECRET_NAME="grafana-mcp-server"
@@ -41,7 +41,7 @@ spec:
                 "${GRAFANA_URL}/api/serviceaccounts/search?query=${SA_NAME}" \
                 | jq -r '.serviceAccounts[] | select(.name=="'"${SA_NAME}"'") | .id // empty')
 
-              if [ -z "$SA_ID" ]; then
+              if [ -z "$SA_ID" ] || [ "$SA_ID" = "null" ]; then
                 echo "Creating service account '${SA_NAME}' with role '{{ .Values.grafanaMCP.serviceAccount.role }}'..."
                 SA_ID=$(curl -sf -X POST \
                   -H "Content-Type: application/json" \
@@ -52,6 +52,11 @@ spec:
                 echo "Service account created with ID: ${SA_ID}"
               else
                 echo "Service account '${SA_NAME}' already exists with ID: ${SA_ID}"
+              fi
+
+              if [ -z "$SA_ID" ] || [ "$SA_ID" = "null" ]; then
+                echo "❌ Failed to get or create service account '${SA_NAME}'"
+                exit 1
               fi
 
               # Delete existing token — tokens cannot be retrieved after creation so rotate on every upgrade
@@ -75,6 +80,11 @@ spec:
                 "${GRAFANA_URL}/api/serviceaccounts/${SA_ID}/tokens" \
                 -d "{\"name\":\"${TOKEN_NAME}\"}" \
                 | jq -r '.key')
+
+              if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+                echo "❌ Failed to create token '${TOKEN_NAME}' — received empty or null response"
+                exit 1
+              fi
 
               # Create or update the K8s secret
               echo "Writing token to secret '${SECRET_NAME}'..."

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -93,6 +93,9 @@ spec:
                 --from-literal=token="${TOKEN}" \
                 --dry-run=client -o yaml | kubectl apply -f -
 
+              # Restart MCP server so it picks up the new token from the updated secret
+              kubectl rollout restart deployment/grafana-mcp-server -n "${NAMESPACE}"
+
               echo "✅ Grafana MCP service account setup complete."
           env:
             - name: GF_ADMIN_USER

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -26,6 +26,13 @@ spec:
                 --from-literal=token="placeholder" 2>/dev/null \
                 && echo "Created placeholder secret grafana-mcp-server" \
                 || echo "Secret grafana-mcp-server already exists, skipping"
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
       serviceAccountName: {{ .Release.Namespace }}-edit-user
       restartPolicy: Never
 {{- if .Values.grafanaMCP.nodeSelector }}
@@ -164,6 +171,13 @@ spec:
                   name: grafanaui
                   key: password
                   optional: true
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
       serviceAccountName: {{ .Release.Namespace }}-edit-user
       restartPolicy: Never
 {{- if .Values.grafanaMCP.nodeSelector }}

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -2,6 +2,40 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  name: grafana-mcp-secret-init
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 30
+  template:
+    spec:
+      containers:
+        - name: grafana-mcp-secret-init
+          image: "{{ .Values.integrationJob.image }}:{{ .Values.integrationJob.imageTag }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # Create secret with placeholder only on first install — skip if it already exists
+              kubectl create secret generic grafana-mcp-server \
+                --namespace="{{ .Release.Namespace }}" \
+                --from-literal=token="placeholder" 2>/dev/null \
+                && echo "Created placeholder secret grafana-mcp-server" \
+                || echo "Secret grafana-mcp-server already exists, skipping"
+      serviceAccountName: {{ .Release.Namespace }}-edit-user
+      restartPolicy: Never
+{{- if .Values.grafanaMCP.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.grafanaMCP.nodeSelector | indent 8 }}
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
   name: grafana-mcp-sa-setup
   namespace: {{ .Release.Namespace }}
   annotations:

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -62,6 +62,12 @@ spec:
                 exit 1
               fi
 
+              SA_ROLE="{{ .Values.grafanaMCP.serviceAccount.role }}"
+              case "${SA_ROLE}" in
+                Viewer|Editor|Admin) ;;
+                *) echo "❌ Invalid grafanaMCP.serviceAccount.role '${SA_ROLE}'. Must be one of: Viewer, Editor, Admin."; exit 1 ;;
+              esac
+
               GRAFANA_URL="{{ .Values.grafanaMCP.grafanaUrl }}"
               SA_NAME="mcp-server"
               TOKEN_NAME="mcp-server-token"
@@ -90,12 +96,12 @@ spec:
                 | jq -r '.serviceAccounts[] | select(.name=="'"${SA_NAME}"'") | .id // empty')
 
               if [ -z "$SA_ID" ] || [ "$SA_ID" = "null" ]; then
-                echo "Creating service account '${SA_NAME}' with role '{{ .Values.grafanaMCP.serviceAccount.role }}'..."
+                echo "Creating service account '${SA_NAME}' with role '${SA_ROLE}'..."
                 SA_ID=$(curl -sf -X POST \
                   -H "Content-Type: application/json" \
                   -u "${GF_ADMIN_USER}:${GF_ADMIN_PASS}" \
                   "${GRAFANA_URL}/api/serviceaccounts" \
-                  -d "{\"name\":\"${SA_NAME}\",\"role\":\"{{ .Values.grafanaMCP.serviceAccount.role }}\"}" \
+                  -d "{\"name\":\"${SA_NAME}\",\"role\":\"${SA_ROLE}\"}" \
                   | jq -r '.id')
                 echo "Service account created with ID: ${SA_ID}"
               else

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.grafanaMCP.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grafana-mcp-sa-setup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - name: grafana-mcp-sa-setup
+          image: "{{ .Values.integrationJob.image }}:{{ .Values.integrationJob.imageTag }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              GRAFANA_URL="http://grafana-ui:3000"
+              SA_NAME="mcp-server"
+              TOKEN_NAME="mcp-server-token"
+              SECRET_NAME="grafana-mcp-server"
+              NAMESPACE="{{ .Release.Namespace }}"
+
+              # Wait for Grafana to be healthy
+              echo "Waiting for Grafana at ${GRAFANA_URL}..."
+              until curl -sf "${GRAFANA_URL}/api/health" > /dev/null; do
+                echo "Grafana not ready, retrying in 10s..."
+                sleep 10
+              done
+              echo "Grafana is ready."
+
+              # Find existing service account or create it
+              SA_ID=$(curl -sf \
+                -u "${GF_ADMIN_USER}:${GF_ADMIN_PASS}" \
+                "${GRAFANA_URL}/api/serviceaccounts/search?query=${SA_NAME}" \
+                | jq -r '.serviceAccounts[] | select(.name=="'"${SA_NAME}"'") | .id // empty')
+
+              if [ -z "$SA_ID" ]; then
+                echo "Creating service account '${SA_NAME}' with role '{{ .Values.grafanaMCP.serviceAccount.role }}'..."
+                SA_ID=$(curl -sf -X POST \
+                  -H "Content-Type: application/json" \
+                  -u "${GF_ADMIN_USER}:${GF_ADMIN_PASS}" \
+                  "${GRAFANA_URL}/api/serviceaccounts" \
+                  -d "{\"name\":\"${SA_NAME}\",\"role\":\"{{ .Values.grafanaMCP.serviceAccount.role }}\"}" \
+                  | jq -r '.id')
+                echo "Service account created with ID: ${SA_ID}"
+              else
+                echo "Service account '${SA_NAME}' already exists with ID: ${SA_ID}"
+              fi
+
+              # Delete existing token — tokens cannot be retrieved after creation so rotate on every upgrade
+              TOKEN_ID=$(curl -sf \
+                -u "${GF_ADMIN_USER}:${GF_ADMIN_PASS}" \
+                "${GRAFANA_URL}/api/serviceaccounts/${SA_ID}/tokens" \
+                | jq -r '.[] | select(.name=="'"${TOKEN_NAME}"'") | .id // empty')
+
+              if [ -n "$TOKEN_ID" ]; then
+                echo "Deleting existing token '${TOKEN_NAME}'..."
+                curl -sf -X DELETE \
+                  -u "${GF_ADMIN_USER}:${GF_ADMIN_PASS}" \
+                  "${GRAFANA_URL}/api/serviceaccounts/${SA_ID}/tokens/${TOKEN_ID}"
+              fi
+
+              # Create new token
+              echo "Creating token '${TOKEN_NAME}'..."
+              TOKEN=$(curl -sf -X POST \
+                -H "Content-Type: application/json" \
+                -u "${GF_ADMIN_USER}:${GF_ADMIN_PASS}" \
+                "${GRAFANA_URL}/api/serviceaccounts/${SA_ID}/tokens" \
+                -d "{\"name\":\"${TOKEN_NAME}\"}" \
+                | jq -r '.key')
+
+              # Create or update the K8s secret
+              echo "Writing token to secret '${SECRET_NAME}'..."
+              kubectl create secret generic "${SECRET_NAME}" \
+                --namespace="${NAMESPACE}" \
+                --from-literal=token="${TOKEN}" \
+                --dry-run=client -o yaml | kubectl apply -f -
+
+              echo "✅ Grafana MCP service account setup complete."
+          env:
+            - name: GF_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafanaui
+                  key: username
+            - name: GF_ADMIN_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafanaui
+                  key: password
+      serviceAccountName: {{ .Release.Namespace }}-edit-user
+      restartPolicy: Never
+{{- if .Values.grafanaMCP.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.grafanaMCP.nodeSelector | indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -169,13 +169,11 @@ spec:
                 secretKeyRef:
                   name: grafanaui
                   key: username
-                  optional: true
             - name: GF_ADMIN_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafanaui
                   key: password
-                  optional: true
           resources:
             requests:
               cpu: "50m"

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -10,6 +10,7 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 0
+  activeDeadlineSeconds: 400
   template:
     spec:
       containers:
@@ -27,10 +28,17 @@ spec:
               SECRET_NAME="grafana-mcp-server"
               NAMESPACE="{{ .Release.Namespace }}"
 
-              # Wait for Grafana to be healthy
+              # Wait for Grafana to be healthy (max 5 minutes)
               echo "Waiting for Grafana at ${GRAFANA_URL}..."
+              MAX_RETRIES=30
+              RETRY=0
               until curl -sf "${GRAFANA_URL}/api/health" > /dev/null; do
-                echo "Grafana not ready, retrying in 10s..."
+                RETRY=$((RETRY + 1))
+                if [ "$RETRY" -ge "$MAX_RETRIES" ]; then
+                  echo "❌ Grafana did not become ready after $((MAX_RETRIES * 10))s"
+                  exit 1
+                fi
+                echo "Grafana not ready, retrying in 10s... ($RETRY/$MAX_RETRIES)"
                 sleep 10
               done
               echo "Grafana is ready."

--- a/charts/aos/templates/grafana-mcp-sa-job.yaml
+++ b/charts/aos/templates/grafana-mcp-sa-job.yaml
@@ -69,13 +69,18 @@ spec:
                 exit 1
               fi
 
+              GRAFANA_URL="{{ .Values.grafanaMCP.grafanaUrl }}"
+              case "${GRAFANA_URL}" in
+                http://*|https://*) ;;
+                *) echo "❌ grafanaMCP.grafanaUrl '${GRAFANA_URL}' must start with http:// or https://"; exit 1 ;;
+              esac
+
               SA_ROLE="{{ .Values.grafanaMCP.serviceAccount.role }}"
               case "${SA_ROLE}" in
                 Viewer|Editor|Admin) ;;
                 *) echo "❌ Invalid grafanaMCP.serviceAccount.role '${SA_ROLE}'. Must be one of: Viewer, Editor, Admin."; exit 1 ;;
               esac
 
-              GRAFANA_URL="{{ .Values.grafanaMCP.grafanaUrl }}"
               SA_NAME="mcp-server"
               TOKEN_NAME="mcp-server-token"
               SECRET_NAME="grafana-mcp-server"

--- a/charts/aos/templates/otel-validation-configmap.yaml
+++ b/charts/aos/templates/otel-validation-configmap.yaml
@@ -342,7 +342,30 @@ data:
       "${GRAFANA_URL}/api/alertmanager/${ALERTMANAGER_DS_UID}/config/api/v1/alerts" \
       '.alertmanager_config.receivers | length' "$MIN_AM_POLICIES"
 
-    # ── Phase 4: Summary ─────────────────────────────────────────────────────
+    # ── Phase 4: MCP Server Checks ──────────────────────────────────────────
+    if [ "${MCP_ENABLED:-false}" = "true" ]; then
+      log "--- Phase 4: Grafana MCP Checks ---"
+
+      # Health check
+      if curl -fsS --max-time 5 "${MCP_SERVER_URL}/health" > /dev/null 2>&1; then
+        add_status 0 "MCP server health (${MCP_SERVER_URL}/health)"
+      else
+        add_status 1 "MCP server health (${MCP_SERVER_URL}/health)"
+      fi
+
+      # SSO proxy reachability
+      if [ "${MCP_PROXY_ENABLED:-false}" = "true" ]; then
+        proxy_status="$(curl -s -o /dev/null -w '%{http_code}' \
+          --max-time 5 'http://grafana-mcp-proxy:80/duplo_auth' 2>/dev/null || echo 000)"
+        if [ "$proxy_status" != "000" ]; then
+          add_status 0 "MCP SSO proxy reachable (HTTP ${proxy_status})"
+        else
+          add_status 1 "MCP SSO proxy unreachable"
+        fi
+      fi
+    fi
+
+    # ── Phase 5: Summary ─────────────────────────────────────────────────────
     trap - EXIT   # cancel the failure trap — we'll send explicitly
     rm -f "$NETRC"
 

--- a/charts/aos/templates/otel-validation-job.yaml
+++ b/charts/aos/templates/otel-validation-job.yaml
@@ -45,6 +45,14 @@ spec:
               value: "{{ .Values.otelValidationJob.pyroDsUid }}"
             - name: ALERTMANAGER_DS_UID
               value: "{{ .Values.otelValidationJob.alertmanagerDsUid }}"
+            - name: MCP_ENABLED
+              value: {{ .Values.grafanaMCP.enabled | quote }}
+{{- if .Values.grafanaMCP.enabled }}
+            - name: MCP_SERVER_URL
+              value: "http://grafana-mcp-server:8080"
+            - name: MCP_PROXY_ENABLED
+              value: {{ .Values.grafanaMCP.proxy.enabled | quote }}
+{{- end }}
             - name: GRAFANA_USER
               valueFrom:
                 secretKeyRef:

--- a/charts/aos/templates/secrets.yaml
+++ b/charts/aos/templates/secrets.yaml
@@ -70,4 +70,4 @@ data:
   hosted-grafana-id: {{ .Values.pdc.config.gc_instance_id | b64enc }}
   token: {{ .Values.pdc.config.pdc_token | b64enc }}
 ---
-{{- end }} 
+{{- end }}

--- a/charts/aos/templates/services.yaml
+++ b/charts/aos/templates/services.yaml
@@ -65,7 +65,7 @@ spec:
     app: grafana-mcp-server
   ports:
     - name: http
-      port: 8080
+      port: 8000
       targetPort: http
       protocol: TCP
 ---

--- a/charts/aos/templates/services.yaml
+++ b/charts/aos/templates/services.yaml
@@ -50,4 +50,40 @@ spec:
       port: 80
       targetPort: proxy
       protocol: TCP
-{{- end }} 
+---
+{{- end }}
+{{- if .Values.grafanaMCP.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-mcp-server
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: grafana-mcp-server
+spec:
+  selector:
+    app: grafana-mcp-server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+---
+{{- end }}
+{{- if and .Values.grafanaMCP.enabled .Values.grafanaMCP.proxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-mcp-proxy
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: grafana-mcp-proxy
+spec:
+  selector:
+    app: grafana-mcp-proxy
+  ports:
+    - name: proxy
+      port: 80
+      targetPort: proxy
+      protocol: TCP
+{{- end }}

--- a/charts/aos/values.yaml
+++ b/charts/aos/values.yaml
@@ -161,7 +161,7 @@ grafanaMCP:
   grafanaUrl: "http://grafana-ui:3000"
   allowedHosts: "*"
   serviceAccount:
-    role: "Editor"
+    role: "Viewer"
   proxy:
     enabled: true
     replicas: 1

--- a/charts/aos/values.yaml
+++ b/charts/aos/values.yaml
@@ -143,6 +143,39 @@ observabilityCollector:
       usernameKey: "username"
       passwordKey: "password"
   
+# Grafana MCP Server settings
+grafanaMCP:
+  enabled: false
+  replicas: 1
+  image: "ghcr.io/grafana/mcp-grafana"
+  imageTag: "v1.0.0"
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "256Mi"
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+  nodeSelector:
+    allocationtags: duplo-observability
+  grafanaUrl: "http://grafana-ui:3000"
+  serviceAccount:
+    role: "Editor"
+  proxy:
+    enabled: true
+    replicas: 1
+    image: "duplocloud/sso-proxy"
+    imageTag: "v2.0.5-otel"
+    resources:
+      limits:
+        cpu: "50m"
+        memory: "128Mi"
+      requests:
+        cpu: "50m"
+        memory: "128Mi"
+    nodeSelector:
+      allocationtags: duplo-observability
+
 # Grafana Cloud PDC settings
 pdc:
   enabled: false

--- a/charts/aos/values.yaml
+++ b/charts/aos/values.yaml
@@ -147,8 +147,8 @@ observabilityCollector:
 grafanaMCP:
   enabled: false
   replicas: 1
-  image: "ghcr.io/grafana/mcp-grafana"
-  imageTag: "v1.0.0"
+  image: "grafana/mcp-grafana"
+  imageTag: "1.0.0"
   resources:
     limits:
       cpu: "100m"
@@ -159,20 +159,12 @@ grafanaMCP:
   nodeSelector:
     allocationtags: duplo-observability
   grafanaUrl: "http://grafana-ui:3000"
+  allowedHosts: "*"
   serviceAccount:
     role: "Editor"
   proxy:
     enabled: true
     replicas: 1
-    image: "duplocloud/sso-proxy"
-    imageTag: "v2.0.5-otel"
-    resources:
-      limits:
-        cpu: "50m"
-        memory: "128Mi"
-      requests:
-        cpu: "50m"
-        memory: "128Mi"
     nodeSelector:
       allocationtags: duplo-observability
 


### PR DESCRIPTION
Summary

Adds a Grafana MCP server to the AOS chart, exposing Grafana capabilities (dashboards, metrics, alerts, annotations) as Model Context Protocol tools for AI agents (Claude Code, Claude Desktop). A DuploCloud SSO proxy sits in front to authenticate requests using Duplo Bearer tokens.

What's included

Feature
- grafana-mcp-server deployment — grafana/mcp-grafana:1.0.0, connects to internal Grafana, exposes MCP tools over SSE
- grafana-mcp-proxy deployment — duplocloud/sso-proxy validates DuploCloud Bearer tokens before proxying to the MCP server
- Kubernetes Service, Ingress (managed in opentelemetry-stack repo), and a post-install/upgrade Job that provisions a Grafana service account and rotates its token on every deploy
- Controlled by grafanaMCP.enabled (default false)

SSE & proxy fixes
- proxy_buffering off in nginx so SSE frames are flushed immediately (default on silently dropped the stream)
- -allowed-hosts=* on mcp-grafana binary to allow ingress host headers (default is localhost:8000)
- Service port aligned to 8000 matching the container (was 8080 — unnecessary remapping)

Reliability
- Pre-install/pre-upgrade hook creates a placeholder grafana-mcp-server secret so the deployment is never blocked waiting for the post-install job
- Post-install/upgrade job rotates the Grafana service account token and triggers rollout restart so the pod always picks up the new token
- 5-minute bounded readiness loop with activeDeadlineSeconds: 400 — job fails fast instead of hanging indefinitely if Grafana is unreachable
- Cleanup job deletes the grafana-mcp-server secret on helm uninstall or when grafanaMCP.enabled: false

Hardening
- Grafana admin credentials validated at script start with actionable error messages
- Service account role validated (Viewer / Editor / Admin) before API call; default changed Editor → Viewer
- grafanaUrl format validated at both Helm render time and job runtime
- Resource limits on all Job containers
- securityContext on grafana-mcp-server (runAsNonRoot, drop ALL caps)
- allowPrivilegeEscalation: false on grafana-mcp-proxy (uwsgi requires CAP_CHOWN so full cap drop is not safe)
- Pod anti-affinity (preferredDuringSchedulingIgnoredDuringExecution) on both de
- Grafana Alloy scrape annotations on grafana-mcp-server

Docs
- README updated with full configuration table, proxy design constraints, and clfor both Claude Code and Claude Desktop (mcp-remote bridge)

Test plan

- [ ] helm upgrade with grafanaMCP.enabled: true — both pods reach Running
- [ ] SSE stream reachable: curl -H "Authorization: Bearer <token>" https://<ingress>/sse returns event: endpoint
- [ ] Claude Code .mcp.json with type: sse connects and lists Grafana tools
- [ ] Claude Desktop with mcp-remote --transport sse-only connects successfully
- [ ] helm upgrade with grafanaMCP.enabled: false — cleanup job deletes grafana-
- [ ] Missing grafanaui secret — setup job pod stays Pending with a clear Kubernetes event
- [ ] Invalid grafanaMCP.serviceAccount.role — helm template fails with actionab